### PR TITLE
Add default within_days value to search struct

### DIFF
--- a/apps/ello_search/lib/ello_search/post/search.ex
+++ b/apps/ello_search/lib/ello_search/post/search.ex
@@ -9,6 +9,7 @@ defmodule Ello.Search.Post.Search do
     terms:          nil,
     current_user:   nil,
     trending:       false,
+    within_days:    nil,
     allow_nsfw:     false,
     allow_nudity:   false,
     query:          %{},


### PR DESCRIPTION
- We were passing this value is from the DiscoveryPost controller; however,
in order for this to override and be merged into the struct, we needed to
have the key already existing.