### PR TITLE
Add following posts new content polling support.

### DIFF
--- a/apps/ello_dispatch/lib/ello_dispatch/endpoint.ex
+++ b/apps/ello_dispatch/lib/ello_dispatch/endpoint.ex
@@ -17,7 +17,6 @@ defmodule Ello.Dispatch.Endpoint do
     pass: ["*/*"],
     json_decoder: Poison
 
-  plug Plug.Head
   plug CORSPlug, [
     headers: ["If-None-Match" | CORSPlug.defaults[:headers]],
     expose:  ["Etag", "X-Total-Count", "X-Total-Pages", "Link",

--- a/apps/ello_v2/lib/ello_v2/endpoint.ex
+++ b/apps/ello_v2/lib/ello_v2/endpoint.ex
@@ -17,7 +17,5 @@ defmodule Ello.V2.Endpoint do
     pass: ["*/*"],
     json_decoder: Poison
 
-  plug Plug.Head
-
   plug Ello.V2.Router
 end

--- a/apps/ello_v2/test/controllers/following_post_controller_test.exs
+++ b/apps/ello_v2/test/controllers/following_post_controller_test.exs
@@ -106,6 +106,7 @@ defmodule Ello.V2.FollowingPostControllerTest do
            |> put_req_header("if-modified-since", "Tue, 06 Jun 2117 12:48:15 GMT")
            |> head(following_post_path(conn, :recent_updated))
     assert %{status: 304} = resp
+    assert [] = get_resp_header(resp, "last-modified")
   end
 
   test "HEAD /v2/following/posts/recent - updated", %{conn: conn} do
@@ -113,6 +114,7 @@ defmodule Ello.V2.FollowingPostControllerTest do
            |> put_req_header("if-modified-since", "Tue, 06 Jun 2007 12:48:15 GMT")
            |> head(following_post_path(conn, :recent_updated))
     assert %{status: 204} = resp
+    assert [_] = get_resp_header(resp, "last-modified")
   end
 
   test "GET /v2/following/posts/trending", context do

--- a/apps/ello_v2/test/controllers/following_post_controller_test.exs
+++ b/apps/ello_v2/test/controllers/following_post_controller_test.exs
@@ -101,6 +101,20 @@ defmodule Ello.V2.FollowingPostControllerTest do
     assert :ok = validate_json("post", json_response(conn, 200))
   end
 
+  test "HEAD /v2/following/posts/recent - not updated", %{conn: conn} do
+    resp = conn
+           |> put_req_header("if-modified-since", "Tue, 06 Jun 2117 12:48:15 GMT")
+           |> head(following_post_path(conn, :recent_updated))
+    assert %{status: 304} = resp
+  end
+
+  test "HEAD /v2/following/posts/recent - updated", %{conn: conn} do
+    resp = conn
+           |> put_req_header("if-modified-since", "Tue, 06 Jun 2007 12:48:15 GMT")
+           |> head(following_post_path(conn, :recent_updated))
+    assert %{status: 204} = resp
+  end
+
   test "GET /v2/following/posts/trending", context do
     %{
       conn: conn,

--- a/apps/ello_v2/web/controllers/following_post_controller.ex
+++ b/apps/ello_v2/web/controllers/following_post_controller.ex
@@ -21,7 +21,9 @@ defmodule Ello.V2.FollowingPostController do
          %{posts: [newest | _]} <- stream,
          :gt <- DateTime.compare(newest.created_at, last_modified) do
       # New post! send 204
-      send_resp(conn, :no_content, "")
+      conn
+      |> put_resp_header("last-modified", Timex.format!(newest.created_at, "{RFC1123}"))
+      |> send_resp(:no_content, "")
     else
       # No new content send 304
       _ -> send_resp(conn, :not_modified, "")

--- a/apps/ello_v2/web/router.ex
+++ b/apps/ello_v2/web/router.ex
@@ -34,6 +34,7 @@ defmodule Ello.V2.Router do
     end
 
     # Following
+    head "/following/posts/recent", FollowingPostController, :recent_updated
     get "/following/posts/recent", FollowingPostController, :recent
     get "/following/posts/trending", FollowingPostController, :trending
   end


### PR DESCRIPTION
Support HEAD /api/v2/following/posts/recent (first page only)

Returns 304 if no new posts, returns 204 if there is new content.

With this merged we can remove all stream reading stuff from the mothership completely.