### PR TITLE
Fix RSS links

### DIFF
--- a/apps/ello_feeds/test/controllers/editorial_controller_test.exs
+++ b/apps/ello_feeds/test/controllers/editorial_controller_test.exs
@@ -18,12 +18,17 @@ defmodule Ello.Feeds.EditorialControllerTest do
     assert xpath(body, ~x"/rss/channel/title/text()"s) == "Ello Editorials"
     assert xpath(body, ~x"/rss/channel/description/text()"s)
     assert xpath(body, ~x"/rss/channel/link/text()"s)
-    assert xpath(body, ~x"/rss/channel/image/link/text()"s)
+    assert xpath(body, ~x"/rss/channel/image/link/text()"s) == "https://ello.co"
     assert xpath(body, ~x"/rss/channel/item[1]/title/text()"s) == "Internal Editorial"
     assert xpath(body, ~x"/rss/channel/item[1]/description/text()"s)
+    assert xpath(body, ~x"/rss/channel/item[1]/link/text()"s) == "https://ello.co/discover/recent"
+
     assert xpath(body, ~x"/rss/channel/item[2]/title/text()"s) == "External Editorial"
     assert xpath(body, ~x"/rss/channel/item[2]/description/text()"s)
+    assert xpath(body, ~x"/rss/channel/item[2]/link/text()"s) =~ "https://ello.co/wtf"
+
     assert xpath(body, ~x"/rss/channel/item[3]/title/text()"s) == "Post Editorial"
     assert xpath(body, ~x"/rss/channel/item[3]/description/text()"s)
+    assert xpath(body, ~x"/rss/channel/item[3]/link/text()"s) =~ ~r"https://ello.co/.*/post/.*"
   end
 end

--- a/apps/ello_feeds/web/views/editorial_view.ex
+++ b/apps/ello_feeds/web/views/editorial_view.ex
@@ -2,24 +2,28 @@ defmodule Ello.Feeds.EditorialView do
   use Ello.Feeds.Web, :view
   import Ello.V2.ImageView, only: [image_url: 2]
 
-  def webapp_url do
-    "https://" <> Application.get_env(:ello_feeds, :webapp_host) <> "/"
+  def webapp_url(path \\ "") do
+    %URI{
+      host:      Application.get_env(:ello_feeds, :webapp_host),
+      authority: Application.get_env(:ello_feeds, :webapp_host),
+      scheme:    "https",
+    } |> URI.merge(path)
   end
 
   def title(editorial), do: editorial.content["title"]
   def description(editorial), do: editorial.content["subtitle"]
 
   def editorial_link(%{kind: "post", post: post}),
-    do: webapp_url() <> post.author.username <> "/post/" <> post.token
+    do: webapp_url(post.author.username <> "/post/" <> post.token)
   def editorial_link(%{kind: "internal"} = editorial),
-    do: webapp_url() <> editorial.content["path"]
+    do: webapp_url(editorial.content["path"])
   def editorial_link(%{kind: "external"} = editorial),
     do: editorial.content["url"]
 
   # Not an actuall valid url, we are just using what the URL would be as a link.
   # We have sent "isPermalink=false" because it isn't a real uri.
   def guid(editorial) do
-    webapp_url() <> "editorials/#{editorial.id}"
+    webapp_url("editorials/#{editorial.id}")
   end
 
   def image_url(%{one_by_one_image_struct: image}) do

--- a/apps/ello_feeds/web/views/editorial_view.ex
+++ b/apps/ello_feeds/web/views/editorial_view.ex
@@ -3,7 +3,7 @@ defmodule Ello.Feeds.EditorialView do
   import Ello.V2.ImageView, only: [image_url: 2]
 
   def webapp_url do
-    "https://" <> Application.get_env(:ello_feeds, :webapp_host)
+    "https://" <> Application.get_env(:ello_feeds, :webapp_host) <> "/"
   end
 
   def title(editorial), do: editorial.content["title"]


### PR DESCRIPTION
We are seeing inconsistent inclusion of / separating host and path in
test/prod. This should ensure consistent formatting.