### PR TITLE
Add default accept header (*/*).

### DIFF
--- a/apps/ello_serve/lib/ello_serve/default_to_html.ex
+++ b/apps/ello_serve/lib/ello_serve/default_to_html.ex
@@ -1,0 +1,18 @@
+defmodule Ello.Serve.DefaultToHTML do
+  @moduledoc """
+  Adds the accepts `*/*` header if the request has no accept header.
+
+  This ensures even clients not sending accepts headers get responses.
+  """
+  @behaviour Plug
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _) do
+    case get_req_header(conn, "accepts") do
+      [] -> put_req_header(conn, "accepts", "*/*")
+      _  -> conn
+    end
+  end
+end

--- a/apps/ello_serve/web/router.ex
+++ b/apps/ello_serve/web/router.ex
@@ -6,6 +6,7 @@ defmodule Ello.Serve.Router do
   end
 
   pipeline :webapp do
+    plug Ello.Serve.DefaultToHTML
     plug :accepts, ["html"]
     plug Ello.Serve.SetApp, app: "webapp"
     plug Ello.Serve.SkipPrerender


### PR DESCRIPTION
Phoenix throws errors if there is no matching accept headers.
Unfortunately there are many terrible clients/crawlers out there
requesting content without an accept header. In that case we add the
wildcard, to which phoenix will serve html.

https://app.honeybadger.io/projects/51139/faults/33289282/7fc60a64-61ab-11e7-84f1-a2a472b408ba#notice-summary