### PR TITLE
Don't double count query times.

### DIFF
--- a/apps/ello_serve/lib/ello_serve/render.ex
+++ b/apps/ello_serve/lib/ello_serve/render.ex
@@ -14,11 +14,9 @@ defmodule Ello.Serve.Render do
   end
   def render_html(conn, data) do
     # Execute any functions
-    measure_segment {__MODULE__, :lazy_load} do
-      data = Enum.reduce data, %{conn: conn}, fn
-        ({key, fun}, accum) when is_function(fun) -> Map.put(accum, key, fun.())
-        ({key, val}, accum) -> Map.put(accum, key, val)
-      end
+    data = Enum.reduce data, %{conn: conn}, fn
+      ({key, fun}, accum) when is_function(fun) -> Map.put(accum, key, fun.())
+      ({key, val}, accum) -> Map.put(accum, key, val)
     end
 
     meta     = render_meta(conn, data)


### PR DESCRIPTION
Because this happens in process we don't need to measure independently.
We are currently getting double measurements here, resulting in segments
larger then the total time.