### PR TITLE
Add ?debug param to enable react app debug.

### DIFF
--- a/apps/ello_serve/lib/ello_serve/render.ex
+++ b/apps/ello_serve/lib/ello_serve/render.ex
@@ -6,6 +6,9 @@ defmodule Ello.Serve.Render do
 
   def render_html(conn, data \\ [])
   def render_html(%{assigns: %{prerender: false, html: html}} = conn, data) do
+    data = data
+           |> Enum.into(%{})
+           |> Map.put(:conn, conn)
     config = render_config(conn, data)
     measure_segment {__MODULE__, :inject_without_prerender} do
       html = inject_config(html, config)
@@ -56,9 +59,9 @@ defmodule Ello.Serve.Render do
     String.replace(body, "</body>", "#{noscript}</body>", global: false)
   end
 
-  defp render_config(%{assigns: %{app: "webapp"}}, _) do
+  defp render_config(%{assigns: %{app: "webapp"}}, data) do
     measure_segment {:render, "config.html"} do
-      render_to_iodata(Webapp.ConfigView, "script.html", [])
+      render_to_iodata(Webapp.ConfigView, "script.html", data)
     end
   end
   defp render_config(_, _), do: ""

--- a/apps/ello_serve/lib/ello_serve/skip_prerender.ex
+++ b/apps/ello_serve/lib/ello_serve/skip_prerender.ex
@@ -4,6 +4,7 @@ defmodule Ello.Serve.SkipPrerender do
   plug :do_fetch_cookies
   plug :set_prerender
   plug :set_logged_in_user
+  plug :set_debug
 
   def do_fetch_cookies(conn, _), do: fetch_cookies(conn)
 
@@ -18,4 +19,10 @@ defmodule Ello.Serve.SkipPrerender do
     do: assign(conn, :logged_in_user?, true)
   defp set_logged_in_user(conn, _),
     do: assign(conn, :logged_in_user?, false)
+
+  defp set_debug(%{params: %{"debug" => "true"}} = conn, _),
+    do: assign(conn, :debug, true)
+  defp set_debug(%{params: %{"debug" => "false"}} = conn, _),
+    do: assign(conn, :debug, false)
+  defp set_debug(conn, _), do: conn
 end

--- a/apps/ello_serve/test/controllers/webapp/no_content_controller_test.exs
+++ b/apps/ello_serve/test/controllers/webapp/no_content_controller_test.exs
@@ -22,6 +22,7 @@ defmodule Ello.Serve.Webapp.NoContentControllerTest do
     assert html =~ ~r(AUTH_CLIENT_ID:.*"client_id",)s
     assert html =~ ~r(AUTH_DOMAIN:.*"https://ello.co",)s
     assert html =~ ~r(LOGO_MARK:.*"normal",)s
+    assert html =~ ~r(APP_DEBUG:.*false,)s
     assert html =~ ~r(PROMO_HOST:.*"https://d9ww8oh3n3brk.cloudfront.net",)s
     assert html =~ ~r(SEGMENT_WRITE_KEY:.*"segment_key")s
     refute html =~ ~r"HONEYBADGER"
@@ -41,6 +42,19 @@ defmodule Ello.Serve.Webapp.NoContentControllerTest do
     assert html =~ ~r(SEGMENT_WRITE_KEY:.*"segment_key")s
     assert html =~ ~r(HONEYBADGER_API_KEY:.*"abc123")s
     assert html =~ ~r(HONEYBADGER_ENVIRONMENT:.*"production")s
+  end
+
+  test "following - it renders config - with debug flag", %{conn: conn} do
+    old = Application.get_env(:ello_serve, :webapp_config)
+    resp = get(conn, "/following", %{"debug" => "false"})
+    html = html_response(resp, 200)
+    assert html =~ ~r"<body><script>.*window.webappEnv = {.*</script>"s
+    assert html =~ ~r(APP_DEBUG:.*false,)s
+
+    resp = get(conn, "/following", %{"debug" => "true"})
+    html = html_response(resp, 200)
+    assert html =~ ~r"<body><script>.*window.webappEnv = {.*</script>"s
+    assert html =~ ~r(APP_DEBUG:.*true,)s
   end
 
   test "following - it renders - preview version", %{conn: conn} do

--- a/apps/ello_serve/web/templates/webapp/config/script.html.eex
+++ b/apps/ello_serve/web/templates/webapp/config/script.html.eex
@@ -3,7 +3,7 @@
     AUTH_CLIENT_ID:    "<%= client_id() %>",
     AUTH_DOMAIN:       "<%= webapp_url("") %>",
     LOGO_MARK:         "<%= logo_mark() %>",
-    APP_DEBUG:         <%= app_debug() %>,
+    APP_DEBUG:         <%= app_debug(@conn) %>,
     PROMO_HOST:        "<%= promo_host() %>",
     SEGMENT_WRITE_KEY: "<%= segment_write_key() %>"
     <%= case honeybadger_config() do %>

--- a/apps/ello_serve/web/views/webapp/config_view.ex
+++ b/apps/ello_serve/web/views/webapp/config_view.ex
@@ -9,7 +9,9 @@ defmodule Ello.Serve.Webapp.ConfigView do
     Application.get_env(:ello_serve, :webapp_config)[:logo_mark]
   end
 
-  def app_debug() do
+  def app_debug(%{assigns: %{debug: true}}),  do: true
+  def app_debug(%{assigns: %{debug: false}}), do: false
+  def app_debug(_) do
     Application.get_env(:ello_serve, :webapp_config)[:app_debug]
   end
 


### PR DESCRIPTION
Adding debug=true or debug=false to a url should set the APP_DEBUG env param in webapp. Allows debugging of issues in production. If nil it defaults to the value in the environment variable.