### PR TITLE
Fix invite show page.

### DIFF
--- a/apps/ello_core/lib/ello_core/contest.ex
+++ b/apps/ello_core/lib/ello_core/contest.ex
@@ -113,6 +113,7 @@ defmodule Ello.Core.Contest do
     |> paginate_submissions(options)
     |> Repo.all
     |> Preload.artist_invite_submissions(options)
+    |> filter_postless
   end
 
   defp for_invite(query, %{invite: %{id: id}}),
@@ -131,5 +132,9 @@ defmodule Ello.Core.Contest do
     query
     |> where([s], s.created_at < ^before)
     |> limit(^per)
+  end
+
+  defp filter_postless(submissions) do
+    Enum.reject(submissions, &(is_nil(&1.post)))
   end
 end

--- a/apps/ello_serve/test/controllers/webapp/artist_invite_show_controller_test.exs
+++ b/apps/ello_serve/test/controllers/webapp/artist_invite_show_controller_test.exs
@@ -11,6 +11,10 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowControllerTest do
     sub1 = Factory.insert(:artist_invite_submission, %{artist_invite: a_inv1, status: "selected", created_at: DateTime.from_unix!(3_000_000)})
     sub2 = Factory.insert(:artist_invite_submission, %{artist_invite: a_inv1, status: "approved", created_at: DateTime.from_unix!(2_000_000)})
     sub3 = Factory.insert(:artist_invite_submission, %{artist_invite: a_inv1, status: "approved", created_at: DateTime.from_unix!(1_000_000)})
+    _sub4 = Factory.insert(:artist_invite_submission, %{
+      artist_invite: a_inv2,
+      status: "selected"
+    })
     {:ok,
       a_inv1: a_inv1,
       a_inv2: a_inv2,

--- a/apps/ello_serve/web/controllers/webapp/artist_invite_show_controller.ex
+++ b/apps/ello_serve/web/controllers/webapp/artist_invite_show_controller.ex
@@ -7,7 +7,7 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowController do
       nil    -> send_resp(conn, 404, "")
       invite -> render_html(conn, %{
         artist_invite: invite,
-        submissions: fn -> submissions(conn, slug) end,
+        submissions: fn -> submissions(conn, invite) end,
       })
     end
   end
@@ -15,9 +15,9 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowController do
   defp artist_invite(conn, slug),
     do: Contest.artist_invite(standard_params(conn, %{id_or_slug: "~#{slug}"}))
 
-  defp submissions(conn, slug) do
+  defp submissions(conn, invite) do
     Contest.artist_invite_submissions(standard_params(conn, %{
-      invite: Contest.artist_invite(%{id_or_slug: "~#{slug}"}),
+      invite: invite,
       status: "approved",
     }))
   end

--- a/apps/ello_serve/web/controllers/webapp/artist_invite_show_controller.ex
+++ b/apps/ello_serve/web/controllers/webapp/artist_invite_show_controller.ex
@@ -7,7 +7,8 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowController do
       nil    -> send_resp(conn, 404, "")
       invite -> render_html(conn, %{
         artist_invite: invite,
-        submissions: fn -> submissions(conn, invite) end,
+        submissions: fn -> submissions(conn, invite, "approved") end,
+        selections: fn -> submissions(conn, invite, "selected") end,
       })
     end
   end
@@ -15,10 +16,17 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowController do
   defp artist_invite(conn, slug),
     do: Contest.artist_invite(standard_params(conn, %{id_or_slug: "~#{slug}"}))
 
-  defp submissions(conn, invite) do
+  defp submissions(conn, invite, "approved") do
     Contest.artist_invite_submissions(standard_params(conn, %{
       invite: invite,
       status: "approved",
     }))
   end
+  defp submissions(conn, %{status: "closed"} = invite, "selected") do
+    Contest.artist_invite_submissions(standard_params(conn, %{
+      invite: invite,
+      status: "selected",
+    }))
+  end
+  defp submissions(_, _, _), do: []
 end

--- a/apps/ello_serve/web/controllers/webapp/artist_invite_show_controller.ex
+++ b/apps/ello_serve/web/controllers/webapp/artist_invite_show_controller.ex
@@ -8,7 +8,7 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowController do
       invite -> render_html(conn, %{
         artist_invite: invite,
         submissions: fn -> submissions(conn, invite, "approved") end,
-        selections: fn -> submissions(conn, invite, "selected") end,
+        selections:  fn -> submissions(conn, invite, "selected") end,
       })
     end
   end
@@ -16,17 +16,10 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowController do
   defp artist_invite(conn, slug),
     do: Contest.artist_invite(standard_params(conn, %{id_or_slug: "~#{slug}"}))
 
-  defp submissions(conn, invite, "approved") do
+  defp submissions(conn, invite, status) do
     Contest.artist_invite_submissions(standard_params(conn, %{
       invite: invite,
-      status: "approved",
+      status: status,
     }))
   end
-  defp submissions(conn, %{status: "closed"} = invite, "selected") do
-    Contest.artist_invite_submissions(standard_params(conn, %{
-      invite: invite,
-      status: "selected",
-    }))
-  end
-  defp submissions(_, _, _), do: []
 end

--- a/apps/ello_serve/web/templates/webapp/artist_invite_show/noscript.html.eex
+++ b/apps/ello_serve/web/templates/webapp/artist_invite_show/noscript.html.eex
@@ -9,7 +9,7 @@
   <p><%= guide_section["raw_body"] %></p>
 <% end %>
 
-<%= if assigns[:selections] do %>
+<%= if length(assigns[:selections]) > 0 do %>
   <h2>Selections</h2>
   <%= for selection <- @selections do %>
     <%= render PostView, "summary.html", Map.put(assigns, :post, selection.post) %>

--- a/apps/ello_serve/web/views/webapp/artist_invite_show_view.ex
+++ b/apps/ello_serve/web/views/webapp/artist_invite_show_view.ex
@@ -2,7 +2,6 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowView do
   use Ello.Serve.Web, :view
   import Ello.V2.ImageView, only: [image_url: 2]
   alias Ello.Serve.Webapp.PostView
-  alias Ello.Core.Contest
 
   def render("meta.html", %{artist_invite: artist_invite} = assigns) do
     assigns = assigns
@@ -10,11 +9,6 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowView do
               |> Map.put(:description, artist_invite.raw_short_description)
               |> Map.put(:robots, "index, follow")
     render_template("meta.html", assigns)
-  end
-
-  def render("noscript.html", %{artist_invite: %{status: "closed"} = invite} = assigns) do
-    assigns = Map.put(assigns, :selections, selections(invite))
-    render_template("noscript.html", assigns)
   end
 
   def artist_invite_image_url(%{header_image_struct: %{path: path, versions: versions}}) do
@@ -28,14 +22,5 @@ defmodule Ello.Serve.Webapp.ArtistInviteShowView do
              |> Map.get(:created_at)
              |> DateTime.to_iso8601
     webapp_url("artist-invites/#{slug}", before: before)
-  end
-
-  defp selections(invite) do
-    Contest.artist_invite_submissions(%{
-      invite: invite,
-      status: "selected",
-      per_page: "25",
-      before: nil,
-    })
   end
 end


### PR DESCRIPTION
Selected submissions needed to be loaded with the standard_params, otherswise preloading failed.

We also need to take into account situations in which a post/author was filtered out (private, blocked, nsfw, etc) and ensure it did not error.