### PR TITLE
Bust Artist Invite cache when status updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
+# Vim projections mapping
+.projections.json
+
 # Ignore local config overrides.
 config/config.local.exs

--- a/apps/ello_core/lib/ello_core/contest/artist_invite.ex
+++ b/apps/ello_core/lib/ello_core/contest/artist_invite.ex
@@ -40,4 +40,18 @@ defmodule Ello.Core.Contest.ArtistInvite do
     |> Map.put(:logo_image_struct, LogoImage.from_artist_invite(artist_invite))
     |> Map.put(:og_image_struct, OGImage.from_artist_invite(artist_invite))
   end
+
+  def status(%{status: "open", closed_at: nil}), do: "open"
+  def status(%{status: "open", opened_at: nil}), do: "upcoming"
+  def status(%{status: "open"} = invite) do
+    now    = DateTime.utc_now |> DateTime.to_unix
+    open   = DateTime.to_unix(invite.opened_at)
+    closed = DateTime.to_unix(invite.closed_at)
+    cond do
+      now < open   -> "upcoming"
+      now > closed -> "selecting"
+      true         -> "open"
+    end
+  end
+  def status(%{status: status}), do: status
 end

--- a/apps/ello_v2/lib/ello_v2/conditional_get.ex
+++ b/apps/ello_v2/lib/ello_v2/conditional_get.ex
@@ -120,6 +120,7 @@ defimpl Ello.V2.ConditionalGet, for: Ello.Core.Contest.ArtistInvite do
       :artist_invite,
       artist_invite.id,
       artist_invite.updated_at,
+      Ello.Core.Contest.ArtistInvite.status(artist_invite),
     ]
     values
     |> :erlang.term_to_binary

--- a/apps/ello_v2/web/views/artist_invite_view.ex
+++ b/apps/ello_v2/web/views/artist_invite_view.ex
@@ -2,6 +2,7 @@ defmodule Ello.V2.ArtistInviteView do
   use Ello.V2.Web, :view
   use Ello.V2.JSONAPI
   alias Ello.V2.{ImageView}
+  alias Ello.Core.Contest.{ArtistInvite}
 
   def stale_checks(_, %{data: artist_invites}) do
     [etag: etag(artist_invites)]
@@ -110,17 +111,5 @@ defmodule Ello.V2.ArtistInviteView do
   end
   defp add_selected_link(links, _, _), do: links
 
-  def status(%{status: "open", closed_at: nil}, _), do: "open"
-  def status(%{status: "open", opened_at: nil}, _), do: "upcoming"
-  def status(%{status: "open"} = invite, _) do
-    now    = DateTime.utc_now |> DateTime.to_unix
-    open   = DateTime.to_unix(invite.opened_at)
-    closed = DateTime.to_unix(invite.closed_at)
-    cond do
-      now < open   -> "upcoming"
-      now > closed -> "selecting"
-      true         -> "open"
-    end
-  end
-  def status(%{status: status}, _), do: status
+  def status(invite, _), do: ArtistInvite.status(invite)
 end


### PR DESCRIPTION
This just mitigates an issue when the status rolls over because of the
time while the invite itself has not been updated.

https://www.pivotaltracker.com/story/show/150598853