### PR TITLE
Fix preview logic.

### DIFF
--- a/apps/ello_core/lib/ello_core/contest.ex
+++ b/apps/ello_core/lib/ello_core/contest.ex
@@ -7,12 +7,12 @@ defmodule Ello.Core.Contest do
     Preload,
   }
 
-  def artist_invite(%{id_or_slug: id_or_slug, preview: "true", current_user: %{is_staff: true}} = options) do
+  def artist_invite(%{id_or_slug: id_or_slug, current_user: %{is_staff: true}} = options) do
     ArtistInvite
     |> Repo.get_by_id_or_slug(id_or_slug: id_or_slug)
     |> Preload.artist_invites(options)
   end
-  def artist_invite(%{id_or_slug: id_or_slug, preview: "true", current_user: %{id: current_user_id}} = options) do
+  def artist_invite(%{id_or_slug: id_or_slug, current_user: %{id: current_user_id}} = options) do
     ArtistInvite
     |> where([ai], ai.brand_account_id == ^current_user_id or ai.status != "preview")
     |> Repo.get_by_id_or_slug(id_or_slug: id_or_slug)

--- a/apps/ello_v2/test/controllers/artist_invite_controller_test.exs
+++ b/apps/ello_v2/test/controllers/artist_invite_controller_test.exs
@@ -119,23 +119,23 @@ defmodule Ello.V2.ArtistInviteControllerTest do
   end
 
 
-  test "GET /v2/artist_invites/:id - staff can preview artist invites", %{staff_conn: conn, a_inv2: a_inv2} do
-    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv2.slug}"), %{preview: "true"})
+  test "GET /v2/artist_invites/:id - staff can see artist invites in preview", %{staff_conn: conn, a_inv2: a_inv2} do
+    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv2.slug}"))
     assert conn.status == 200
   end
 
-  test "GET /v2/artist_invites/:id - brand accounts can preview their own artist invite", %{brand_conn: conn, a_inv3: a_inv3} do
-    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv3.slug}"), %{preview: "true"})
+  test "GET /v2/artist_invites/:id - brand accounts can see their own artist invite in preview", %{brand_conn: conn, a_inv3: a_inv3} do
+    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv3.slug}"))
     assert conn.status == 200
   end
 
   test "GET /v2/artist_invites/:id - brand accounts can't preview other artist invites", %{brand_conn: conn, a_inv2: a_inv2} do
-    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv2.slug}"), %{preview: "true"})
+    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv2.slug}"))
     assert conn.status == 404
   end
 
   test "GET /v2/artist_invites/:id - normal users can't view preview artist invites", %{conn: conn, a_inv2: a_inv2} do
-    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv2.slug}"), %{preview: "true"})
+    conn = get(conn, artist_invite_path(conn, :show, "~#{a_inv2.slug}"))
     assert conn.status == 404
   end
 

--- a/apps/ello_v2/web/controllers/artist_invite_controller.ex
+++ b/apps/ello_v2/web/controllers/artist_invite_controller.ex
@@ -14,10 +14,9 @@ defmodule Ello.V2.ArtistInviteController do
     |> api_render_if_stale(data: artist_invites)
   end
 
-  def show(conn, %{"id" => id_or_slug} = params) do
+  def show(conn, %{"id" => id_or_slug}) do
     artist_invite = Contest.artist_invite(standard_params(conn, %{
       id_or_slug: id_or_slug,
-      preview: params["preview"]
     }))
     api_render_if_stale(conn, data: artist_invite)
   end

--- a/apps/ello_v2/web/views/artist_invite_view.ex
+++ b/apps/ello_v2/web/views/artist_invite_view.ex
@@ -96,14 +96,13 @@ defmodule Ello.V2.ArtistInviteView do
   end
   defp add_unapproved_link(links, _, _), do: links
 
-  defp add_approved_link(links, %{id: id, status: status}, _) when status in ["open", "closed"] do
+  defp add_approved_link(links, %{id: id}, _) do
     Map.put(links, :approved_submissions, %{
       label: "Approved",
       type:  "artist_invite_submission_stream",
       href:  "/api/v2/artist_invites/#{id}/submissions?status=approved",
     })
   end
-  defp add_approved_link(links, _, _), do: links
 
   defp add_selected_link(links, %{id: id, brand_account_id: user_id}, %{id: user_id}) do
     Map.put(links, :selected_submissions, %{


### PR DESCRIPTION
We should not require the "preview" flag on show, just only show if
preview and staff/brand user.