### PR TITLE
Adds ability to see another user's following stream

### DIFF
--- a/apps/ello_v2/test/controllers/following_post_controller_test.exs
+++ b/apps/ello_v2/test/controllers/following_post_controller_test.exs
@@ -96,7 +96,7 @@ defmodule Ello.V2.FollowingPostControllerTest do
     refute nudity_post.id in returned_ids
   end
 
-  test "GET /v2/following/user/~user", %{unauth_conn: unauth_conn, following_user: following_user, post: post, my_post: my_post} do
+  test "GET /v2/following/users/~user", %{unauth_conn: unauth_conn, following_user: following_user, post: post, my_post: my_post} do
     staff_user = Factory.insert(:user, %{is_staff: true})
     conn = unauth_conn
            |> auth_conn(staff_user)
@@ -110,7 +110,7 @@ defmodule Ello.V2.FollowingPostControllerTest do
     refute my_post.id in returned_ids
   end
 
-  test "GET /v2/following/user/~user fails for non-staff", %{conn: conn, following_user: following_user} do
+  test "GET /v2/following/users/~user fails for non-staff", %{conn: conn, following_user: following_user} do
     response = conn
                |> get(following_post_path(conn, :user, "#{following_user.id}"))
     assert response.status == 404

--- a/apps/ello_v2/test/controllers/following_post_controller_test.exs
+++ b/apps/ello_v2/test/controllers/following_post_controller_test.exs
@@ -96,7 +96,6 @@ defmodule Ello.V2.FollowingPostControllerTest do
     refute nudity_post.id in returned_ids
   end
 
-  @tag :focus
   test "GET /v2/following/user/~user", %{unauth_conn: unauth_conn, following_user: following_user, post: post, my_post: my_post} do
     staff_user = Factory.insert(:user, %{is_staff: true})
     conn = unauth_conn
@@ -111,7 +110,6 @@ defmodule Ello.V2.FollowingPostControllerTest do
     refute my_post.id in returned_ids
   end
 
-  @tag :focus
   test "GET /v2/following/user/~user fails for non-staff", %{conn: conn, following_user: following_user} do
     response = conn
                |> get(following_post_path(conn, :user, "#{following_user.id}"))

--- a/apps/ello_v2/test/controllers/following_post_controller_test.exs
+++ b/apps/ello_v2/test/controllers/following_post_controller_test.exs
@@ -39,6 +39,7 @@ defmodule Ello.V2.FollowingPostControllerTest do
         conn: auth_conn(conn, user),
         unauth_conn: conn,
         user: user,
+        following_user: following_user,
         post: post,
         my_post: my_post,
         nudity_post: nudity_post,
@@ -93,6 +94,17 @@ defmodule Ello.V2.FollowingPostControllerTest do
     assert my_post.id in returned_ids
     refute nsfw_post.id in returned_ids
     refute nudity_post.id in returned_ids
+  end
+
+  @tag :focus
+  test "GET /v2/following/user/~user", %{conn: conn, following_user: following_user, post: post, my_post: my_post} do
+    response = conn
+               |> get(following_post_path(conn, :user, "#{following_user.id}"))
+    assert response.status == 200
+    json = json_response(response, 200)
+    returned_ids = Enum.map(json["posts"], &(String.to_integer(&1["id"])))
+    assert post.id in returned_ids
+    refute my_post.id in returned_ids
   end
 
   @tag :json_schema

--- a/apps/ello_v2/test/controllers/following_post_controller_test.exs
+++ b/apps/ello_v2/test/controllers/following_post_controller_test.exs
@@ -97,7 +97,11 @@ defmodule Ello.V2.FollowingPostControllerTest do
   end
 
   @tag :focus
-  test "GET /v2/following/user/~user", %{conn: conn, following_user: following_user, post: post, my_post: my_post} do
+  test "GET /v2/following/user/~user", %{unauth_conn: unauth_conn, following_user: following_user, post: post, my_post: my_post} do
+    staff_user = Factory.insert(:user, %{is_staff: true})
+    conn = unauth_conn
+           |> auth_conn(staff_user)
+
     response = conn
                |> get(following_post_path(conn, :user, "#{following_user.id}"))
     assert response.status == 200
@@ -105,6 +109,13 @@ defmodule Ello.V2.FollowingPostControllerTest do
     returned_ids = Enum.map(json["posts"], &(String.to_integer(&1["id"])))
     assert post.id in returned_ids
     refute my_post.id in returned_ids
+  end
+
+  @tag :focus
+  test "GET /v2/following/user/~user fails for non-staff", %{conn: conn, following_user: following_user} do
+    response = conn
+               |> get(following_post_path(conn, :user, "#{following_user.id}"))
+    assert response.status == 404
   end
 
   @tag :json_schema

--- a/apps/ello_v2/web/controllers/following_post_controller.ex
+++ b/apps/ello_v2/web/controllers/following_post_controller.ex
@@ -46,6 +46,16 @@ defmodule Ello.V2.FollowingPostController do
     |> api_render_if_stale(PostView, :index, data: results.results)
   end
 
+  def user(%{assigns: %{current_user: %{is_staff: true}}} = conn, %{"slug" => id_or_username}) do
+    user = Network.user(%{
+      id_or_username: id_or_username,
+      current_user: current_user(conn)
+    })
+    Stream.fetch(standard_params(conn, %{
+      keys: ["#{user.id}" | Network.following_ids(user)],
+    }))
+  end
+
   defp trending_search(conn) do
     Search.post_search(standard_params(conn, %{
       trending:     true,

--- a/apps/ello_v2/web/controllers/following_post_controller.ex
+++ b/apps/ello_v2/web/controllers/following_post_controller.ex
@@ -56,7 +56,7 @@ defmodule Ello.V2.FollowingPostController do
     }))
 
     conn
-    |> add_pagination_headers("/following/user/#{user.id}/posts/recent", stream)
+    |> add_pagination_headers("/following/users/#{user.id}/posts/recent", stream)
     |> api_render(PostView, :index, data: stream.posts)
   end
   def user(conn, _), do: send_resp(conn, 404, "")

--- a/apps/ello_v2/web/controllers/following_post_controller.ex
+++ b/apps/ello_v2/web/controllers/following_post_controller.ex
@@ -51,10 +51,15 @@ defmodule Ello.V2.FollowingPostController do
       id_or_username: id_or_username,
       current_user: current_user(conn)
     })
-    Stream.fetch(standard_params(conn, %{
+    stream = Stream.fetch(standard_params(conn, %{
       keys: ["#{user.id}" | Network.following_ids(user)],
     }))
+
+    conn
+    |> add_pagination_headers("/following/user/#{user.id}/posts/recent", stream)
+    |> api_render(PostView, :index, data: stream.posts)
   end
+  def user(conn, _), do: send_resp(conn, 404, "")
 
   defp trending_search(conn) do
     Search.post_search(standard_params(conn, %{

--- a/apps/ello_v2/web/router.ex
+++ b/apps/ello_v2/web/router.ex
@@ -40,7 +40,7 @@ defmodule Ello.V2.Router do
     head "/following/posts/recent", FollowingPostController, :recent_updated
     get "/following/posts/recent", FollowingPostController, :recent
     get "/following/posts/trending", FollowingPostController, :trending
-    get "/following/user/:slug/posts/recent", FollowingPostController, :user
+    get "/following/users/:slug/posts/recent", FollowingPostController, :user
 
     # Artist Invites
     resources "/artist_invites", ArtistInviteController, only: @read do

--- a/apps/ello_v2/web/router.ex
+++ b/apps/ello_v2/web/router.ex
@@ -40,6 +40,7 @@ defmodule Ello.V2.Router do
     head "/following/posts/recent", FollowingPostController, :recent_updated
     get "/following/posts/recent", FollowingPostController, :recent
     get "/following/posts/trending", FollowingPostController, :trending
+    get "/following/user/:slug", FollowingPostController, :user
 
     # Artist Invites
     resources "/artist_invites", ArtistInviteController, only: @read do

--- a/apps/ello_v2/web/router.ex
+++ b/apps/ello_v2/web/router.ex
@@ -40,7 +40,7 @@ defmodule Ello.V2.Router do
     head "/following/posts/recent", FollowingPostController, :recent_updated
     get "/following/posts/recent", FollowingPostController, :recent
     get "/following/posts/trending", FollowingPostController, :trending
-    get "/following/user/:slug", FollowingPostController, :user
+    get "/following/user/:slug/posts/recent", FollowingPostController, :user
 
     # Artist Invites
     resources "/artist_invites", ArtistInviteController, only: @read do


### PR DESCRIPTION
If you are staff, you can fetch another user's stream using the `/following/user/:id/posts/recent` endpoint.

[Finishes #152216687](https://www.pivotaltracker.com/story/show/152216687)