### PR TITLE
Quick fix for Artist Invite pagination

### DIFF
--- a/apps/ello_v2/lib/ello_v2/pagination.ex
+++ b/apps/ello_v2/lib/ello_v2/pagination.ex
@@ -74,7 +74,7 @@ defmodule Ello.V2.Pagination do
 
   @filter_slop 3 # Don't 204 if one blocked post gets filtered out
   defp add_last_page_header(conn, structs, filter_slop \\ @filter_slop) do
-    requested = standard_params(conn, %{})[:per_page]
+    requested = standard_params(conn)[:per_page]
     if requested - filter_slop > length(structs) do
       conn
       |> put_resp_header("x-last-page", "true")

--- a/apps/ello_v2/web/controllers/artist_invite_controller.ex
+++ b/apps/ello_v2/web/controllers/artist_invite_controller.ex
@@ -8,7 +8,6 @@ defmodule Ello.V2.ArtistInviteController do
   def index(conn, params) do
     artist_invites = Contest.artist_invites(standard_params(conn, %{
       preview: params["preview"],
-      default: %{per_page: 20},
     }))
     conn
     |> add_pagination_headers("/artist_invites", artist_invites)

--- a/apps/ello_v2/web/controllers/editorials_controller.ex
+++ b/apps/ello_v2/web/controllers/editorials_controller.ex
@@ -22,7 +22,8 @@ defmodule Ello.V2.EditorialController do
   defp next_page_params([], _), do: %{}
   defp next_page_params(editorials, conn) do
     last_editorial = List.last(editorials)
-    next = %{per_page: per_page(conn)}
+    per_page = standard_params(conn)[:per_page]
+    next = %{per_page: per_page}
     if preview?(conn) do
       Map.merge(next, %{
         before: last_editorial.preview_position,
@@ -37,17 +38,13 @@ defmodule Ello.V2.EditorialController do
 
   defp last_page_header(conn, editorials) do
     editorials_count = length(editorials)
-    per_page = per_page(conn)
+    per_page = standard_params(conn)[:per_page]
     if editorials_count < per_page do
       put_resp_header(conn, "x-total-pages-remaining", "0")
     else
       put_resp_header(conn, "x-total-pages-remaining", "1")
     end
   end
-
-  defp per_page(%{params: %{"per_page" => per_page}}) when is_binary(per_page), do: String.to_integer(per_page)
-  defp per_page(%{params: %{"per_page" => per_page}}), do: per_page
-  defp per_page(_), do: 25
 
   defp preview?(%{assigns: %{current_user: %{is_staff: true}}, params: %{"preview" => _}}), do: true
   defp preview?(_), do: false


### PR DESCRIPTION
The default of `per_page: 20` is only being used by iOS, but it breaks infinite scroll because that `20` *isn't* being in pagination.ex, so the system default 25 is used there instead, which triggers a "not enough items - no more pages" bug.

[Finishes #152762802](https://www.pivotaltracker.com/story/show/152762802)