### PR TITLE
Fix preloads from fragments.

### DIFF
--- a/apps/ello_v3/lib/ello_v3/schema/network_types.ex
+++ b/apps/ello_v3/lib/ello_v3/schema/network_types.ex
@@ -52,8 +52,8 @@ defmodule Ello.V3.Schema.NetworkTypes do
     field :relationship_priority, :string, resolve: &relationship_priority/2
   end
 
-  def relationship_priority(_, %{source: %{id: id}, context: %{current_user: %{id: id}}}), do: {:ok, "self"}
-  def relationship_priority(_, %{source: %{relationship_to_current_user: nil}}), do: {:ok, nil}
-  def relationship_priority(_, %{source: %{relationship_to_current_user: %{priority: p}}}), do: {:ok, p}
-  def relationship_priority(_args, _resolution), do: {:ok, nil}
+  defp relationship_priority(_, %{source: %{id: id}, context: %{current_user: %{id: id}}}), do: {:ok, "self"}
+  defp relationship_priority(_, %{source: %{relationship_to_current_user: nil}}), do: {:ok, nil}
+  defp relationship_priority(_, %{source: %{relationship_to_current_user: %{priority: p}}}), do: {:ok, p}
+  defp relationship_priority(_args, _resolution), do: {:ok, nil}
 end

--- a/apps/ello_v3/test/ello_v3/resolvers/user_post_stream_test.exs
+++ b/apps/ello_v3/test/ello_v3/resolvers/user_post_stream_test.exs
@@ -117,7 +117,9 @@ defmodule Ello.V3.Resolvers.UserPostStreamTest do
       }
     }
     """
-    resp = post_graphql(%{query: query})
+    current_user = Factory.insert(:user)
+    Factory.insert(:relationship, owner: current_user, subject: context.user, priority: "friend")
+    resp = post_graphql(%{query: query}, current_user)
     json = json_response(resp)
     author = hd(json["data"]["userPostStream"]["posts"])["author"]
     author_keys = Map.keys(author)
@@ -134,5 +136,6 @@ defmodule Ello.V3.Resolvers.UserPostStreamTest do
     assert "has_loves_enabled" in settings_keys
     assert "is_collaborateable" in settings_keys
     assert "is_hireable" in settings_keys
+    assert author["current_user_state"]["relationship_priority"] == "friend"
   end
 end


### PR DESCRIPTION
We were getting an extra nesting level we didn't want, for example:

%{author: %{user: %{current_user_state: %{}}}}

Instead of:

%{author: %{current_user_state: %{}}}