### PR TITLE
Optionally include the category with page headers.

### DIFF
--- a/apps/ello_core/lib/ello_core/discovery.ex
+++ b/apps/ello_core/lib/ello_core/discovery.ex
@@ -181,7 +181,7 @@ defmodule Ello.Core.Discovery do
     |> page_promotional_by_login_status(options[:kind], options[:current_user])
     |> limit(^per_page)
     |> Repo.all
-    |> Preload.promotionals(options)
+    |> Preload.page_promotionals(options)
   end
 
   defp page_promotional_by_kind(q, :editorial), do: where(q, is_editorial: true)

--- a/apps/ello_core/lib/ello_core/discovery/preload.ex
+++ b/apps/ello_core/lib/ello_core/discovery/preload.ex
@@ -27,6 +27,13 @@ defmodule Ello.Core.Discovery.Preload do
     |> build_promotional_images
   end
 
+  def page_promotionals([], _), do: []
+  def page_promotionals(promotions, options) do
+    promotions
+    |> page_promotional_includes(options)
+    |> build_promotional_images
+  end
+
   defp include_promotionals(categories, %{promotionals: true} = options) do
     Repo.preload(categories, promotionals: [user: &Network.users(%{ids: &1, current_user: options[:current_user]})])
   end
@@ -38,6 +45,16 @@ defmodule Ello.Core.Discovery.Preload do
       ({:user, user_preloads}) ->
         {:user, &Network.users(%{ids: &1, current_user: options[:current_user], preloads: user_preloads})}
     end
+    Repo.preload(promotionals, preloads)
+  end
+
+  defp page_promotional_includes(promotionals, %{preloads: preloads} = options) do
+    preloads = Enum.map preloads, fn
+      ({:user, user_preloads}) ->
+        {:user, &Network.users(%{ids: &1, current_user: options[:current_user], preloads: user_preloads})}
+      _ -> nil
+    end
+    preloads = Enum.filter(preloads, &(&1))
     Repo.preload(promotionals, preloads)
   end
 

--- a/apps/ello_v3/lib/ello_v3/resolvers/page_headers.ex
+++ b/apps/ello_v3/lib/ello_v3/resolvers/page_headers.ex
@@ -4,7 +4,7 @@ defmodule Ello.V3.Resolvers.PageHeaders do
 
   def call(_, %{kind: :category} = args, _) do
     # We always need category to "proxy" header, title, etc
-    args = Map.put(args, :preloads, Map.merge(args[:preloads], %{category: %{}}))
+    args = Map.put(args, :preloads, Map.merge(%{category: %{}}, args[:preloads]))
     {:ok, Discovery.promotionals(args)}
   end
 

--- a/apps/ello_v3/lib/ello_v3/schema/discovery_types.ex
+++ b/apps/ello_v3/lib/ello_v3/schema/discovery_types.ex
@@ -25,6 +25,7 @@ defmodule Ello.V3.Schema.DiscoveryTypes do
     field :subheader, :string, resolve: &page_header_sub_header/2
     field :cta_link, :page_header_cta_link, resolve: &page_header_cta_link/2
     field :image, :responsive_image_versions, resolve: &page_header_image/2
+    field :category, :category
   end
 
   enum :page_header_kind do

--- a/apps/ello_v3/test/ello_v3/resolvers/page_headers_test.exs
+++ b/apps/ello_v3/test/ello_v3/resolvers/page_headers_test.exs
@@ -37,6 +37,7 @@ defmodule Ello.V3.Resolvers.PageHeadersTest do
         subheader
         image { ...pageHeaderImageVersions }
         ctaLink { text url }
+        category { id }
         user {
           username
           avatar { ...avatarImageVersion }
@@ -80,6 +81,7 @@ defmodule Ello.V3.Resolvers.PageHeadersTest do
     assert json["ctaLink"]["text"] == "Click HERE!"
     assert json["ctaLink"]["url"] == "https://ello.co/"
     assert json["user"]["username"] == "ello"
+    assert json["category"]["id"] == "#{cat1.id}"
     assert json["image"]
   end
 
@@ -103,6 +105,7 @@ defmodule Ello.V3.Resolvers.PageHeadersTest do
     assert json["ctaLink"]["url"] == "https://ello.co/"
     assert json["user"]["username"] == "ello"
     assert %{} = json["user"]["avatar"]
+    assert json["category"] == nil
     assert json["image"]
   end
 


### PR DESCRIPTION
This allows us to check subscription status even if we don't have the
category data.