### PR TITLE
Adds category_user to category queries.

### DIFF
--- a/apps/ello_core/lib/ello_core/discovery/category.ex
+++ b/apps/ello_core/lib/ello_core/discovery/category.ex
@@ -4,6 +4,9 @@ defmodule Ello.Core.Discovery.Category do
     CategoryPost,
     Promotional,
   }
+  alias Ello.Core.Network.{
+    CategoryUser,
+  }
   alias __MODULE__.TileImage
 
   @type t :: %__MODULE__{}
@@ -30,6 +33,7 @@ defmodule Ello.Core.Discovery.Category do
 
     has_many :promotionals, Promotional
     has_many :category_posts, CategoryPost
+    has_many :category_users, CategoryUser
   end
 
   @doc """

--- a/apps/ello_v3/lib/ello_v3/resolvers/category.ex
+++ b/apps/ello_v3/lib/ello_v3/resolvers/category.ex
@@ -1,0 +1,6 @@
+defmodule Ello.V3.Resolvers.Category do
+  alias Ello.Core.{Discovery}
+
+  def call(_parent, args, _resolver),
+    do: {:ok, Discovery.category(Map.merge(args, %{id_or_slug: args[:slug]}))}
+end

--- a/apps/ello_v3/lib/ello_v3/resolvers/category_users.ex
+++ b/apps/ello_v3/lib/ello_v3/resolvers/category_users.ex
@@ -1,0 +1,9 @@
+defmodule Ello.V3.Resolvers.CategoryUsers do
+  alias Ello.Core.Discovery.Category
+
+  # Assuming preloaded category_users on category, with roles taken into account
+  def call(%Category{category_users: cusers}, _args, _resolution) when is_list(cusers) do
+    {:ok, cusers}
+  end
+  def call(%Category{id: _id}, _args, _resolution), do: {:ok, []}
+end

--- a/apps/ello_v3/lib/ello_v3/resolvers/find_post.ex
+++ b/apps/ello_v3/lib/ello_v3/resolvers/find_post.ex
@@ -7,6 +7,18 @@ defmodule Ello.V3.Resolvers.FindPost do
     check_username(post, args[:username], args)
   end
 
+  def call(_parent, %{id: id} = args, _resolver) do
+    args = Map.put(args, :preloads, Map.merge(%{author: %{}}, args.preloads))
+    post = Ello.Core.Content.post(Map.merge(args, %{id_or_token: id}))
+    check_username(post, args[:username], args)
+  end
+
+  def call(_parent, %{token: token} = args, _resolver) do
+    args = Map.put(args, :preloads, Map.merge(%{author: %{}}, args.preloads))
+    post = Ello.Core.Content.post(Map.merge(args, %{id_or_token: "~#{token}"}))
+    check_username(post, args[:username], args)
+  end
+
   defp check_username(post, nil, args), do: {:ok, do_track(post, args)}
   defp check_username(%{author: %{username: u}} = post, u, args), do: {:ok, do_track(post, args)}
   defp check_username(_, _, _), do: {:error, "Post not found"}

--- a/apps/ello_v3/lib/ello_v3/schema.ex
+++ b/apps/ello_v3/lib/ello_v3/schema.ex
@@ -13,7 +13,8 @@ defmodule Ello.V3.Schema do
   query do
     @desc "Get a post by username and token"
     field :post, :post do
-      arg :token,    non_null(:string)
+      arg :id, :id
+      arg :token, :string
       arg :username, :string, description: "Username post belongs to"
       resolve &Resolvers.FindPost.call/3
     end

--- a/apps/ello_v3/lib/ello_v3/schema.ex
+++ b/apps/ello_v3/lib/ello_v3/schema.ex
@@ -49,6 +49,12 @@ defmodule Ello.V3.Schema do
       resolve &Resolvers.Categories.call/3
     end
 
+    @desc "Returns a signle (active) category"
+    field :category, :category do
+      arg :slug, non_null(:string)
+      resolve &Resolvers.Category.call/3
+    end
+
     @desc "Stream of posts across the network"
     field :global_post_stream, :post_stream do
       arg :kind, non_null(:stream_kind), description: "Which variation of the stream to return"

--- a/apps/ello_v3/lib/ello_v3/schema/discovery_types.ex
+++ b/apps/ello_v3/lib/ello_v3/schema/discovery_types.ex
@@ -1,5 +1,6 @@
 defmodule Ello.V3.Schema.DiscoveryTypes do
   use Absinthe.Schema.Notation
+  alias Ello.V3.Resolvers
 
   object :category do
     field :id, :id
@@ -13,6 +14,10 @@ defmodule Ello.V3.Schema.DiscoveryTypes do
     field :allow_in_onboarding, :boolean
     field :is_creator_type, :boolean
     field :created_at, :datetime
+    field :category_users, list_of(:category_user) do
+      arg :roles, list_of(:category_user_role)
+      resolve &Resolvers.CategoryUsers.call/3
+    end
   end
 
   object :category_post do
@@ -37,6 +42,21 @@ defmodule Ello.V3.Schema.DiscoveryTypes do
     field :href, :string
     field :label, :string
     field :method, :string
+  end
+
+  object :category_user do
+    field :id, :id
+    field :role, :category_user_role
+    field :created_at, :datetime
+    field :updated_at, :datetime
+    field :category, :category
+    field :user, :user
+  end
+
+  enum :category_user_role do
+    value :moderator, as: "moderator"
+    value :curator, as: "curator"
+    value :featured, as: "featured"
   end
 
   object :page_header do

--- a/apps/ello_v3/lib/ello_v3/schema/discovery_types.ex
+++ b/apps/ello_v3/lib/ello_v3/schema/discovery_types.ex
@@ -8,6 +8,7 @@ defmodule Ello.V3.Schema.DiscoveryTypes do
     field :slug, :string
     field :level, :string
     field :order, :integer
+    field :description, :string
     field :tile_image, :tshirt_image_versions, resolve: fn(_args, %{source: category}) ->
       {:ok, category.tile_image_struct}
     end

--- a/apps/ello_v3/test/ello_v3/resolvers/category_test.exs
+++ b/apps/ello_v3/test/ello_v3/resolvers/category_test.exs
@@ -1,0 +1,80 @@
+defmodule Ello.V3.Resolvers.CategoryTest do
+  use Ello.V3.Case
+
+  setup do
+    cat1 = Factory.insert(:category, level: "secondary", id: 3)
+    cu1 = Factory.insert(:category_user, category: cat1, role: "featured")
+    cu2 = Factory.insert(:category_user, category: cat1, role: "curator")
+    cu3 = Factory.insert(:category_user, category: cat1, role: "moderator")
+
+    {:ok,
+      cat1: cat1,
+      cu1: cu1,
+      cu2: cu2,
+      cu3: cu3,
+    }
+  end
+
+  test "Returns the category", %{cat1: cat1} do
+    query = """
+    {
+      category(slug: "#{cat1.slug}") {
+          id
+          name
+          slug
+          level
+          order
+          tile_image {
+            small {
+              url
+              metadata {
+                width
+                height
+                size
+                type
+              }
+            }
+          }
+        }
+    }
+    """
+
+    resp = post_graphql(%{query: query})
+    assert %{"data" => %{"category" => json}} = json_response(resp)
+    assert json["id"] == "#{cat1.id}"
+  end
+
+  test "Returns the category with users", %{cat1: cat1, cu2: cu2, cu2: cu3} do
+    query = """
+      query($slug: String, $roles: [CategoryUserRole]) {
+        category(slug: $slug) {
+          id
+          slug
+          categoryUsers(roles: $roles) {
+            id
+            role
+            user {
+              id
+              username
+            }
+          }
+        }
+      }
+    """
+
+    resp = post_graphql(%{
+      query: query,
+      variables: %{slug: cat1.slug, roles: ["CURATOR", "MODERATOR"]},
+    })
+    assert %{"data" => %{"category" => json}} = json_response(resp)
+    assert json["id"] == "#{cat1.id}"
+    assert [_jcu2, _jcu3] = users = json["categoryUsers"]
+
+    assert "#{cu2.id}" in Enum.map(users, &(&1["id"]))
+    assert "#{cu3.id}" in Enum.map(users, &(&1["id"]))
+    assert "CURATOR" in Enum.map(users, &(&1["role"]))
+    assert "MODERATOR" in Enum.map(users, &(&1["role"]))
+    assert cu2.user.username in Enum.map(users, &(&1["user"]["username"]))
+    assert cu3.user.username in Enum.map(users, &(&1["user"]["username"]))
+  end
+end

--- a/apps/ello_v3/test/ello_v3/resolvers/find_post_test.exs
+++ b/apps/ello_v3/test/ello_v3/resolvers/find_post_test.exs
@@ -140,6 +140,30 @@ defmodule Ello.V3.Resolvers.FindPostTest do
     assert json["summary"] == post.rendered_summary
   end
 
+  test "Abbreviated post representation - by id", %{post: post} do
+    query = """
+      query($id: ID!) {
+        post(id: $id) {
+          id
+          token
+          createdAt
+          summary {
+            link_url
+            kind
+            data
+          }
+        }
+      }
+    """
+
+    resp = post_graphql(%{query: query, variables: %{id: post.id}})
+    assert %{"data" => %{"post" => json}} = json_response(resp)
+    assert json["id"] == "#{post.id}"
+    assert json["token"] == "#{post.token}"
+    assert json["createdAt"] == DateTime.to_iso8601(post.created_at)
+    assert json["summary"] == post.rendered_summary
+  end
+
   test "Abbreviated post representation - wrong username", %{post: post} do
     query = """
       query($username: String!, $token: String!) {

--- a/apps/ello_v3/test/ello_v3/schema_test.exs
+++ b/apps/ello_v3/test/ello_v3/schema_test.exs
@@ -56,6 +56,12 @@ defmodule Ello.V3.SchemaTest do
     assert "allCategories" in Enum.map(json, &(&1["name"]))
   end
 
+  test "has a category query" do
+    resp = post_graphql(%{query: @query_list_query})
+    json = json_response(resp)["data"]["__schema"]["queryType"]["fields"]
+    assert "category" in Enum.map(json, &(&1["name"]))
+  end
+
   test "has a categoryPostStream query" do
     resp = post_graphql(%{query: @query_list_query})
     json = json_response(resp)["data"]["__schema"]["queryType"]["fields"]


### PR DESCRIPTION
Category Users can be included in any category query and filtered by
role. We also add a query for getting a single category at a time.