### PR TITLE
If token is invalid, user will be nil.

### DIFF
--- a/apps/ello_core/lib/ello_core/network/preload.ex
+++ b/apps/ello_core/lib/ello_core/network/preload.ex
@@ -30,6 +30,7 @@ defmodule Ello.Core.Network.Preload do
     users(user_or_users, Map.put(options, :preloads, @user_default_preloads))
   end
 
+  def is_spammer(nil), do: nil
   def is_spammer(user) do
     Map.put(user, :is_spammer, Network.flags_exist?(%{user: user, kind: "spam", verified: true}))
   end


### PR DESCRIPTION
Don't 500 in this case, just treat the request as un-authenticated and
401.