### PR TITLE
Don’t include the entire args map when finding the post

### DIFF
--- a/apps/ello_v3/lib/ello_v3/resolvers/comment_stream.ex
+++ b/apps/ello_v3/lib/ello_v3/resolvers/comment_stream.ex
@@ -7,7 +7,7 @@ defmodule Ello.V3.Resolvers.CommentStream do
   def call(_parent, %{token: token} = args, _resolution), do: resolve_comments(token, args)
 
   defp resolve_comments(id_or_token, args) do
-    case Content.post(Map.merge(args, %{id_or_token: id_or_token})) do
+    case Content.post(%{id_or_token: id_or_token, current_user: args.current_user}) do
       nil -> {:error, "Post not found"}
       post -> comments = Content.comments(Map.merge(args, %{post: post}))
 

--- a/apps/ello_v3/test/ello_v3/resolvers/comment_stream_test.exs
+++ b/apps/ello_v3/test/ello_v3/resolvers/comment_stream_test.exs
@@ -58,4 +58,27 @@ defmodule Ello.V3.Resolvers.CommentStreamTest do
     assert %{"data" => %{"commentStream" => json2}} = json_response(resp2)
     assert %{"isLastPage" => true, "next" => _, "comments" => []} = json2
   end
+
+  test "Comment stream - when using the id with a repost", _ do
+    original_post = Factory.insert(:post)
+    repost = Factory.insert(:post, %{reposted_source: original_post})
+    comment1 = Factory.insert(:comment, %{parent_post: original_post, created_at:  DateTime.from_unix!(100_000_000)})
+    comment2 = Factory.insert(:comment, %{parent_post: original_post, created_at:  DateTime.from_unix!(100_000_100)})
+    comment3 = Factory.insert(:comment, %{parent_post: original_post, created_at:  DateTime.from_unix!(100_000_200)})
+
+    resp = post_graphql(%{query: @query, variables: %{"id" => repost.id, "perPage" => 3}})
+    assert %{"data" => %{"commentStream" => json}} = json_response(resp)
+    assert %{"comments" => comments, "next" => next, "isLastPage" => false} = json
+    assert to_string(comment3.id) in Enum.map(comments, &(&1["id"]))
+    assert to_string(comment2.id) in Enum.map(comments, &(&1["id"]))
+    assert to_string(comment1.id) in Enum.map(comments, &(&1["id"]))
+    assert to_string(comment3.author.id) in Enum.map(comments, &(&1["author"]["id"]))
+    assert to_string(comment2.author.id) in Enum.map(comments, &(&1["author"]["id"]))
+    assert to_string(comment1.author.id) in Enum.map(comments, &(&1["author"]["id"]))
+    assert to_string(comment1.parent_post.id) in Enum.map(comments, &(&1["parentPost"]["id"]))
+
+    resp2 = post_graphql(%{query: @query, variables: %{"id" => repost.id, "before" => next, "perPage" => 3}})
+    assert %{"data" => %{"commentStream" => json2}} = json_response(resp2)
+    assert %{"isLastPage" => true, "next" => _, "comments" => []} = json2
+  end
 end


### PR DESCRIPTION
- This was inadvertently using the comment preloads. Instead, we will
use the default post preloads when finding the post