### PR TITLE
Ensure notification created_at is formatted right

### DIFF
--- a/apps/ello_notifications/lib/ello_notifications/stream.ex
+++ b/apps/ello_notifications/lib/ello_notifications/stream.ex
@@ -57,6 +57,6 @@ defmodule Ello.Notifications.Stream do
 
   defp set_next(%{models: []} = stream), do: stream
   defp set_next(%{models: models} = stream) do
-    %{stream | next: List.last(models).created_at}
+    %{stream | next: DateTime.to_iso8601(List.last(models).created_at)}
   end
 end

--- a/apps/ello_notifications/mix.exs
+++ b/apps/ello_notifications/mix.exs
@@ -33,6 +33,7 @@ defmodule Ello.Notifications.Mixfile do
     [
       {:httpoison, "~> 1.0"},
       {:jason, "~> 1.0"},
+      {:timex, "~> 3.0"},
 
       {:ello_core, in_umbrella: true},
     ]

--- a/apps/ello_v3/lib/ello_v3/resolvers/notification_stream.ex
+++ b/apps/ello_v3/lib/ello_v3/resolvers/notification_stream.ex
@@ -19,9 +19,8 @@ defmodule Ello.V3.Resolvers.NotificationStream do
 
   def new_content(_parent, %{current_user: current_user} = args, _resolution) do
     with stream <- Stream.fetch(Map.merge(args, %{preload: false, per_page: 1})),
-         %{models: [%{created_at: newest} | _]} <- stream,
+         %{models: [%{created_at: newest_dt} | _]} <- stream,
          last_read when is_number(last_read) <- User.last_read_notification_time(current_user),
-         {:ok, newest_dt, _} <- DateTime.from_iso8601(newest),
          {:ok, last_read_dt} <- DateTime.from_unix(last_read),
          1 <- Timex.compare(newest_dt, last_read_dt, :seconds) do
       {:ok, %{new_content: true}}

--- a/apps/ello_v3/lib/ello_v3/schema/notification_types.ex
+++ b/apps/ello_v3/lib/ello_v3/schema/notification_types.ex
@@ -33,7 +33,7 @@ defmodule Ello.V3.Schema.NotificationTypes do
     field :subject_id, :id
     field :subject_type, :string, resolve: &notification_subject_type/2
     field :subject, :notification_subject
-    field :created_at, :string
+    field :created_at, :datetime
   end
 
   union :notification_subject do


### PR DESCRIPTION
The notification streams service returns an unusual datetime format, so
don't just pass it through as is. Instead we parse and re-format into
the same format all graphql dates are in.