### PR TITLE
Limit excluded ids in notification api call.

### DIFF
--- a/apps/ello_core/lib/ello_core/network/user.ex
+++ b/apps/ello_core/lib/ello_core/network/user.ex
@@ -103,8 +103,20 @@ defmodule Ello.Core.Network.User do
     |> MapSet.new
   end
 
+  def silenced_and_inverse_blocked_ids(%__MODULE__{} = user, limit \\ 5000) do
+    full_set = MapSet.union(silenced_ids(user), inverse_blocked_ids(user))
+    Enum.take(full_set, limit)
+  end
+
   defp inverse_blocked_ids(%__MODULE__{id: id}) do
     {:ok, ids} = Redis.command(["SMEMBERS", "user:#{id}:inverse_block_id_cache"], name: :inverse_blocked_ids)
+    ids
+    |> Enum.map(&String.to_integer/1)
+    |> MapSet.new
+  end
+
+  defp silenced_ids(%__MODULE__{id: id}) do
+    {:ok, ids} = Redis.command(["SMEMBERS", "user:#{id}:silence_id_cache"], name: :silenced_ids)
     ids
     |> Enum.map(&String.to_integer/1)
     |> MapSet.new

--- a/apps/ello_events/lib/ello_events/mark_notifications_as_read.ex
+++ b/apps/ello_events/lib/ello_events/mark_notifications_as_read.ex
@@ -21,5 +21,8 @@ defmodule Ello.Events.MarkNotificationsAsRead do
       _ -> 0
     end
   end
+  defp parse_last_notification_time(%{last_notification_time: %DateTime{} = time}) do
+    DateTime.to_unix(time)
+  end
   defp parse_last_notification_time(%{last_notification_time: time}), do: time
 end

--- a/apps/ello_notifications/lib/ello_notifications/stream/client/http.ex
+++ b/apps/ello_notifications/lib/ello_notifications/stream/client/http.ex
@@ -1,5 +1,6 @@
 defmodule Ello.Notifications.Stream.Client.HTTP do
   use HTTPoison.Base
+  alias Ello.Core.Network.User
   alias Ello.Notifications.Stream.{
     Client,
     Item,
@@ -43,12 +44,15 @@ defmodule Ello.Notifications.Stream.Client.HTTP do
   defp user_path(user_id), do: "/api/v1/users/#{user_id}/notifications"
 
   defp to_params(stream) do
+    exclude = stream.current_user
+              |> User.silenced_and_inverse_blocked_ids(500)
+              |> Enum.join(",")
     %{
       user_id: stream.current_user.id,
       limit: stream.per_page,
       before: stream.before,
       category: stream.category,
-      exclude_originating_user_ids: Enum.join(stream.current_user.all_blocked_ids, ","),
+      exclude_originating_user_ids: exclude,
     }
   end
 


### PR DESCRIPTION
Subject queries will handled blocked requests anyway, so this is mainly
to reduce handling the issue after the query instead of before.